### PR TITLE
Use Python 3 print and __future__ for compatibility.

### DIFF
--- a/mindwave.py
+++ b/mindwave.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import select, serial, threading
 from pprint import pprint
 import time
@@ -47,7 +49,7 @@ class OfflineHeadset:
 
     def setupfile(self):
         self.datasetfile = self.basefilename
-        print self.datasetfile
+        print(self.datasetfile)
         if os.path.isfile(self.datasetfile):
             if self.f:
                 self.f.close()


### PR DESCRIPTION
I've added the ability to use a mindwave-python connector to the [mindwavelsl tool](https://github.com/gmierz/mindwave-lsl). However, when I vendored the file, there's a `print` statement that only works with Python 2. This patch converts it to `print()` and also adds the `__future__` import in case anyone still uses the deprecated Python 2.